### PR TITLE
config comment for "Alias name" does not match behaviour

### DIFF
--- a/src/main/java/com/floragunn/searchguard/ssl/util/SSLCertificateHelper.java
+++ b/src/main/java/com/floragunn/searchguard/ssl/util/SSLCertificateHelper.java
@@ -46,7 +46,7 @@ public class SSLCertificateHelper {
 
         String evaluatedAlias = alias;
 
-        if (alias == null && aliases.size() == 1) {
+        if (alias == null && aliases.size() > 0) {
             evaluatedAlias = aliases.get(0);
         }
 


### PR DESCRIPTION
the comment says:

"(default: **first alias** which could be found)"

but this appears to be the case when there is only a single alias.