### PR TITLE
Fixes a memory leak in the Task Manager

### DIFF
--- a/src/main/java/com/floragunn/searchguard/ssl/transport/SearchGuardSSLTransportService.java
+++ b/src/main/java/com/floragunn/searchguard/ssl/transport/SearchGuardSSLTransportService.java
@@ -129,7 +129,7 @@ public class SearchGuardSSLTransportService extends TransportService {
                     request.putInContext("_sg_ssl_transport_peer_certificates", x509Certs);
                     request.putInContext("_sg_ssl_transport_protocol", sslhandler.getEngine().getSession().getProtocol());
                     request.putInContext("_sg_ssl_transport_cipher", sslhandler.getEngine().getSession().getCipherSuite());
-                    messageReceivedDecorate(request, handler, nettyChannel, task);
+                    messageReceivedDecorate(request, handler, transportChannel, task);
                 } else {
                     final String msg = "No X509 transport client certificates found (SG 12)";
                     log.error(msg);


### PR DESCRIPTION
Unwrapping the transport channel and not calling messageReceived on the original channel skips unregistering of tasks in the task manager, which in turn causes a small memory leak each time an action is started on a remote node. It was originally reported as elastic/elasticsearch#19794